### PR TITLE
fileIdx 쿼리 추가되게 수정

### DIFF
--- a/src/components/codeEditer/FileList.js
+++ b/src/components/codeEditer/FileList.js
@@ -12,6 +12,7 @@ const FileList = ({ fileList, setFileList, socket, admin }) => {
   const params = useParams();
 
   const handleSelectId = (id) => {
+    navigate(`/room/${params.roomId}?fileIdx=${id}`);
     setSelectId(id);
 
     socket.emit('openFile', {


### PR DESCRIPTION
## 📄 Summary

> pushCode emti 에서 `fileIdx` 가 null 로 뜨는 문제를 수정합니다.

## 🙋🏻 More

https://github.com/hyunyeee/code-share-fe/blob/34069b8de74b782a5e54354c9b511c86499aa48a/src/pages/Main.js#L20
이 코드에서 searchParams 로 `fileIdx` 를 받아와 pushCode emit 발동 시 처리하도록 되어있었는데, https://github.com/hyunyeee/code-share-fe/pull/21/commits/f2574e69556af64191a94c14e7b7da2d0b410582 이 커밋에서 모르고 제거했습니다.

따라서 다시 추가해줍니다.